### PR TITLE
fixed bug in rmsd example

### DIFF
--- a/examples/rmsd.f90
+++ b/examples/rmsd.f90
@@ -29,7 +29,7 @@ program rmsd_
 
         ! Only allocate on the first iteration. This assume a constant number
         ! of particles
-        if (i == 0) then
+        if (i == 1) then
             call frame%atoms_count(natoms)
             allocate(positions(3, natoms))
         end if


### PR DESCRIPTION
Led to segfault since `i` is one at the start of the loop.